### PR TITLE
New features for reverse proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 caddy_sites_reverse_proxy: []
 caddy_sites_redirect: []
+compression: false

--- a/readme.md
+++ b/readme.md
@@ -15,11 +15,16 @@ Configure Caddy sites role.
     - ansible.builtin.include_role:
         name: ansible-caddy-sites
       vars:
+        compression: true
         caddy_sites_reverse_proxy:
           - domain_name: "test1.example.com"
             destination_url: https://example.com
           - domain_name: "test2.example.com"
             destination_url: https://example.com
+            rewrite: 
+              - rule: /foo /bar
+            alias:
+              domain: www.test1.example.com
             headers_up:
               - operation: +
                 field: Host
@@ -27,6 +32,7 @@ Configure Caddy sites role.
             tls_dns:
               provider: digitalocean
               config: xxx
+            compression: false
         caddy_sites_redirect:
           - domain_name: "test1.example.com"
             destination_url: https://example.com

--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,6 @@ Configure Caddy sites role.
             destination_url: https://example.com
           - domain_name: "test2.example.com"
             destination_url: https://example.com
-            rewrite: 
-              - rule: /foo /bar
             alias:
               domain: www.test1.example.com
             headers_up:

--- a/templates/redirect.j2
+++ b/templates/redirect.j2
@@ -1,4 +1,4 @@
-{{ site['domain_name'] }} {
+{{ site['domain_name'] }}{% if site['alias'] is defined %}{% for alias in site['alias'] %}, {{ alias['domain'] }}{% endfor %}{% endif %} {
   redir {{ site['destination_url'] }}{uri}{% if site['permanent'] is defined and site['permanent'] %} permanent{% endif %}
 
   log {

--- a/templates/reverse_proxy.j2
+++ b/templates/reverse_proxy.j2
@@ -21,12 +21,6 @@
   encode zstd gzip 
 {% endif %}
 
-{% if site['rewrite'] is defined %}
-{% for rewrite_rule in site['rewrite'] %}
-   rewrite {{ rewrite_rule.rule }}
-{% endfor %}
-{% endif %}
-
   log {
     output file /var/log/caddy/{{ site['domain_name'] }}-access.log {
       roll_size 50MiB

--- a/templates/reverse_proxy.j2
+++ b/templates/reverse_proxy.j2
@@ -1,4 +1,4 @@
-{{ site['domain_name'] }} {
+{{ site['domain_name'] }}{% if site['alias'] is defined %}{% for alias in site['alias'] %}, {{ alias['domain'] }}{% endfor %}{% endif %} {
   reverse_proxy {
     to {{ site['destination_url'] }}
 
@@ -14,6 +14,19 @@
 {% endif %}
 
   }
+
+{# Check for global or local compression option #}
+{% if (compression is defined and compression == true 
+     and not (site.compression is defined and site.compression != true)) 
+     or (site.compression is defined and site.compression == true) %} 
+  encode zstd gzip 
+{% endif %}
+
+{% if site['rewrite'] is defined %}
+{% for rewrite_rule in site['rewrite'] %}
+   rewrite {{ rewrite_rule.rule }}
+{% endfor %}
+{% endif %}
 
   log {
     output file /var/log/caddy/{{ site['domain_name'] }}-access.log {

--- a/templates/reverse_proxy.j2
+++ b/templates/reverse_proxy.j2
@@ -16,8 +16,7 @@
   }
 
 {# Check for global or local compression option #}
-{% if (compression is defined and compression == true 
-     and not (site.compression is defined and site.compression != true)) 
+{% if (compression == true and not (site.compression is defined and site.compression != true)) 
      or (site.compression is defined and site.compression == true) %} 
   encode zstd gzip 
 {% endif %}


### PR DESCRIPTION
Since we're in the process of migrating all our domains to Caddy, we're encountering a few configurations that are not yet supported by the playbook.
I've opened this pull request more as a request for feedback (so feel free to reject it), as we're very likely to add more features in the next few days.

What I've done for now:
- added alias
- added rewrite
- added compression option, global and local, with local taking precedence
- updated documentation

Regarding the compression option, maybe we should render this default for all proxies with option to disable.

For the very complex cases we're thinking that some kind of "raw" option to directly write to the config file, or even supply the entire config file will be a more pragmatic approach.

Please let me know what you think about it.
